### PR TITLE
[codex] Fix v2 draft cutover and optimize migration

### DIFF
--- a/drizzle/0004_phase8_result_status_optional_wing.sql
+++ b/drizzle/0004_phase8_result_status_optional_wing.sql
@@ -1,14 +1,5 @@
 ALTER TABLE "assessment_results" ALTER COLUMN "wing_type" DROP NOT NULL;
-ALTER TABLE "assessment_results" ADD COLUMN "result_status" text;
-ALTER TABLE "assessment_results" ADD COLUMN "confidence_score" real;
-
-UPDATE "assessment_results"
-SET "result_status" = 'clear'
-WHERE "result_status" IS NULL;
-
-UPDATE "assessment_results"
-SET "confidence_score" = 0
-WHERE "confidence_score" IS NULL;
-
-ALTER TABLE "assessment_results" ALTER COLUMN "result_status" SET NOT NULL;
-ALTER TABLE "assessment_results" ALTER COLUMN "confidence_score" SET NOT NULL;
+ALTER TABLE "assessment_results" ADD COLUMN "result_status" text NOT NULL DEFAULT 'clear';
+ALTER TABLE "assessment_results" ADD COLUMN "confidence_score" real NOT NULL DEFAULT 0;
+ALTER TABLE "assessment_results" ALTER COLUMN "result_status" DROP DEFAULT;
+ALTER TABLE "assessment_results" ALTER COLUMN "confidence_score" DROP DEFAULT;

--- a/src/app/api/assessment-session/route.ts
+++ b/src/app/api/assessment-session/route.ts
@@ -61,6 +61,10 @@ async function readCanonicalDraft() {
   };
 }
 
+function isActiveAssessmentVersion(version: string) {
+  return version === assessmentDefinition.version;
+}
+
 export async function GET() {
   const draft = await readCanonicalDraft();
 
@@ -102,7 +106,7 @@ export async function POST(request: Request) {
 
     const existingDraft = await readCanonicalDraft();
 
-    if (existingDraft) {
+    if (existingDraft && isActiveAssessmentVersion(existingDraft.session.assessmentVersion)) {
       return Response.json(
         {
           session: toSnapshot(existingDraft.session),
@@ -113,9 +117,13 @@ export async function POST(request: Request) {
 
     const repository = new DrizzleAssessmentDraftSessionRepository();
     const adminStatsEventRepository = new DrizzleAdminStatsEventRepository();
-    const sessionToken = createAssessmentDraftSessionToken();
+    const sessionToken = existingDraft?.sessionToken ?? createAssessmentDraftSessionToken();
     const session = buildEmptyDraftSession();
     const now = new Date();
+
+    if (existingDraft) {
+      await repository.deleteDraftSession(existingDraft.sessionToken);
+    }
 
     await repository.createDraftSession({
       sessionToken,

--- a/test/assessment/assessment-session-route.test.ts
+++ b/test/assessment/assessment-session-route.test.ts
@@ -4,6 +4,7 @@ import { getTableColumns } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { assessmentDefinition } from "@/content/assessments";
+import { assessmentDefinition as assessmentDefinitionV1 } from "@/content/assessments/ko/v1";
 import {
   ADMIN_STATS_EVENT_TYPES,
   type AdminStatsEventRepository,
@@ -285,6 +286,21 @@ function buildDraftSnapshot(): AssessmentDraftSessionSnapshot {
   };
 }
 
+function buildLegacyDraftSnapshot(): AssessmentDraftSessionSnapshot {
+  return {
+    assessmentVersion: assessmentDefinitionV1.version,
+    answers: {
+      [assessmentDefinitionV1.questions[0]!.id]: 5,
+    },
+    progress: {
+      answeredCount: 1,
+      totalQuestions: assessmentDefinitionV1.questions.length,
+      currentQuestionId: assessmentDefinitionV1.questions[1]!.id,
+      isComplete: false,
+    },
+  };
+}
+
 describe("assessment draft session contract", () => {
   it("defines an opaque anonymous assessment cookie boundary", () => {
     const token = createAssessmentDraftSessionToken();
@@ -500,6 +516,84 @@ describe("assessment session routes", () => {
     });
     expect(cookieStore.setCalls).toHaveLength(0);
     expect(adminStatsEventRepository.events).toEqual([]);
+  });
+
+  it("resets a stored legacy-version draft session during active-version bootstrap", async () => {
+    const legacySnapshot = buildLegacyDraftSnapshot();
+    const cookieStore = new FakeCookiesStore({
+      [ASSESSMENT_DRAFT_SESSION_COOKIE.name]: "legacy-token",
+    });
+    const repository = new FakeDraftSessionRepository(
+      new Map([
+        [
+          "legacy-token",
+          {
+            id: "draft-legacy-token",
+            sessionToken: "legacy-token",
+            assessmentVersion: legacySnapshot.assessmentVersion,
+            draftAnswers: legacySnapshot.answers,
+            draftProgress: legacySnapshot.progress,
+            createdAt: new Date("2026-03-29T12:00:00.000Z"),
+            updatedAt: new Date("2026-03-29T12:00:00.000Z"),
+          },
+        ],
+      ]),
+    );
+    const adminStatsEventRepository = new FakeAdminStatsEventRepository();
+
+    cookiesMock.mockResolvedValue(cookieStore);
+    repositoryConstructorMock.mockImplementation(() => repository);
+    adminStatsEventRepositoryConstructorMock.mockImplementation(
+      () => adminStatsEventRepository,
+    );
+
+    const routeModule = await import("@/app/api/assessment-session/route");
+    const postResponse = await routeModule.POST(
+      new Request("http://localhost/api/assessment-session", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          assessmentVersion: assessmentDefinition.version,
+        }),
+      }),
+    );
+    const getResponse = await routeModule.GET();
+
+    await expect(postResponse.json()).resolves.toEqual({
+      session: {
+        assessmentVersion: assessmentDefinition.version,
+        answers: {},
+        progress: {
+          answeredCount: 0,
+          totalQuestions: assessmentDefinition.questions.length,
+          currentQuestionId: assessmentDefinition.questions[0]!.id,
+          isComplete: false,
+        },
+      },
+    });
+    await expect(getResponse.json()).resolves.toEqual({
+      session: {
+        assessmentVersion: assessmentDefinition.version,
+        answers: {},
+        progress: {
+          answeredCount: 0,
+          totalQuestions: assessmentDefinition.questions.length,
+          currentQuestionId: assessmentDefinition.questions[0]!.id,
+          isComplete: false,
+        },
+      },
+    });
+    expect(cookieStore.setCalls).toEqual([
+      {
+        name: ASSESSMENT_DRAFT_SESSION_COOKIE.name,
+        value: "legacy-token",
+        options: ASSESSMENT_DRAFT_SESSION_COOKIE.options,
+      },
+    ]);
+    expect(adminStatsEventRepository.events).toHaveLength(1);
+    expect(adminStatsEventRepository.events[0]?.eventType).toBe(
+      ADMIN_STATS_EVENT_TYPES.assessmentStarted,
+    );
   });
 
   it("clears the canonical draft session through an explicit delete boundary", async () => {


### PR DESCRIPTION
## Summary
- reset stored legacy draft sessions during `/api/assessment-session` bootstrap when the active assessment version has changed
- keep the same session token/cookie while recreating the canonical draft against the active `v2` definition
- rewrite the `0004` migration to use `NOT NULL DEFAULT ...` plus `DROP DEFAULT` instead of backfilling with separate `UPDATE` statements

## Why
The merged v2 rollout left one real cutover bug: a returning user with a stored `v1` draft cookie could re-enter the flow, answer `v2` questions, and then hit `INCOMPLETE_ANSWER_COVERAGE` on submit because the draft session version stayed on `v1`.

## Reviewer Focus
- legacy `v1` draft sessions should be recreated as fresh active-version drafts during bootstrap
- normal active-version draft reuse should remain unchanged
- the migration should preserve the same schema outcome while avoiding explicit table-wide backfill updates

## Validation
- `npm exec vitest run test/assessment/assessment-session-route.test.ts test/assessment/mobile-flow.test.ts test/assessment/assessment-submit.test.ts test/assessment/result-persistence.test.ts test/ops/postgres-restore-runbook.test.ts`
- `npm run typecheck`
