### PR TITLE
[codex] fix postgres pool reuse causing runaway CPU

### DIFF
--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -4,15 +4,45 @@ import { Pool } from "pg";
 import { getEnv } from "@/env";
 import * as schema from "@/db/schema";
 
+type GlobalDbState = typeof globalThis & {
+  __assessmentDbPool?: Pool;
+  __assessmentDb?: ReturnType<typeof drizzle<typeof schema>>;
+  __assessmentDbUrl?: string;
+};
+
+function getGlobalDbState(): GlobalDbState {
+  return globalThis as GlobalDbState;
+}
+
 export function createDb(databaseUrl: string = getEnv().DATABASE_URL) {
+  const globalDbState = getGlobalDbState();
+
+  if (
+    globalDbState.__assessmentDb &&
+    globalDbState.__assessmentDbPool &&
+    globalDbState.__assessmentDbUrl === databaseUrl
+  ) {
+    return globalDbState.__assessmentDb;
+  }
+
   const pool = new Pool({
     connectionString: databaseUrl,
+    max: 10,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 10_000,
+    allowExitOnIdle: true,
   });
 
-  return drizzle({
+  const db = drizzle({
     client: pool,
     schema,
   });
+
+  globalDbState.__assessmentDbPool = pool;
+  globalDbState.__assessmentDb = db;
+  globalDbState.__assessmentDbUrl = databaseUrl;
+
+  return db;
 }
 
 export type AssessmentDb = ReturnType<typeof createDb>;

--- a/test/ops/db-client.test.ts
+++ b/test/ops/db-client.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const poolInstances: Array<Record<string, unknown>> = [];
+const drizzleClients: Array<Record<string, unknown>> = [];
+
+vi.mock("pg", () => ({
+  Pool: vi.fn().mockImplementation((options: Record<string, unknown>) => {
+    const pool = {
+      options,
+    };
+
+    poolInstances.push(pool);
+
+    return pool;
+  }),
+}));
+
+vi.mock("drizzle-orm/node-postgres", () => ({
+  drizzle: vi.fn().mockImplementation((config: Record<string, unknown>) => {
+    const db = {
+      config,
+    };
+
+    drizzleClients.push(db);
+
+    return db;
+  }),
+}));
+
+describe("db client", () => {
+  afterEach(() => {
+    poolInstances.length = 0;
+    drizzleClients.length = 0;
+
+    const globalDbState = globalThis as typeof globalThis & {
+      __assessmentDbPool?: unknown;
+      __assessmentDb?: unknown;
+      __assessmentDbUrl?: string;
+    };
+
+    delete globalDbState.__assessmentDbPool;
+    delete globalDbState.__assessmentDb;
+    delete globalDbState.__assessmentDbUrl;
+
+    vi.resetModules();
+  });
+
+  it("reuses the same postgres pool for repeated createDb calls with the same url", async () => {
+    const { createDb } = await import("../../src/db/client");
+
+    const first = createDb("postgres://postgres:postgres@db:5432/enneagram");
+    const second = createDb("postgres://postgres:postgres@db:5432/enneagram");
+
+    expect(first).toBe(second);
+    expect(poolInstances).toHaveLength(1);
+    expect(drizzleClients).toHaveLength(1);
+    expect(poolInstances[0]).toMatchObject({
+      options: {
+        connectionString: "postgres://postgres:postgres@db:5432/enneagram",
+        max: 10,
+        idleTimeoutMillis: 30_000,
+        connectionTimeoutMillis: 10_000,
+        allowExitOnIdle: true,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- reuse a single process-wide `pg.Pool` instead of creating a new pool on every repository access
- add conservative pool settings for idle timeout and connection timeout
- add an ops test that proves repeated `createDb` calls reuse the same pool

## Why
The app was constructing a new PostgreSQL pool for each request path that instantiated a repository. In a long-lived Coolify container, those pools and their timers can accumulate and drive sustained CPU usage over time.

## Impact
- reduces background pool churn in production
- lowers the chance of CPU climbing to 80-100% after the process has been up for a while
- gives us a regression test around DB client lifecycle behavior

## Validation
- `npm test -- test/ops/db-client.test.ts test/ops/health-route.test.ts`

## Notes
- local SSH push from this machine failed because `git@github.com` was not authenticated, so the branch and PR were published through the GitHub connector instead
- `test-results/` was left out of the PR because it is generated test output